### PR TITLE
added log max size & backup count

### DIFF
--- a/utbox/bin/ut_log.py
+++ b/utbox/bin/ut_log.py
@@ -7,7 +7,10 @@ def setup_logger():
     logger.setLevel(logging.DEBUG)
 
     file_handler = logging.handlers.RotatingFileHandler(
-        os.environ['SPLUNK_HOME'] + '/var/log/splunk/utbox.log')
+        os.environ['SPLUNK_HOME'] + '/var/log/splunk/utbox.log',
+        maxBytes=25000000,
+        backupCount=3
+        )
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
     file_handler.setFormatter(formatter)
 

--- a/utbox/default/app.conf
+++ b/utbox/default/app.conf
@@ -5,7 +5,7 @@ label = URL Toolbox
 [launcher]
 author = Cedric Le Roux
 description = Parse URLs like a Pro.
-version = 1.9.2
+version = 1.9.3
 
 [package]
 id = utbox


### PR DESCRIPTION
Added maxBytes & backupCount to stop the log from from growing out of control and consuming all of the disk space.  Note this is best practice to include per https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler.

Closes #8